### PR TITLE
fix: 修复匹配false字符串时的报错

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -275,6 +275,6 @@ export default class Tokenizer {
   getTokenOnFirstMatch({ input, type, regex }) {
     const matches = input.match(regex);
 
-    return matches ? { type, value: matches[1] } : undefined;
+    return matches && matches[1] ? { type, value: matches[1] } : undefined;
   }
 }


### PR DESCRIPTION
问题：匹配false字符串时，matches[1]不存在，导致后续通过value调用方法时（比如v.slice）报错
修复：matches[1]使用时加个异常判断
测试：单测通过